### PR TITLE
Application 구동을 위한 Dockerfile 작성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM public.ecr.aws/docker/library/gradle:7.4.2-jdk17 AS builder
+
+WORKDIR /home/gradle/app
+
+COPY gradle gradle
+COPY gradlew .
+COPY build.gradle .
+COPY settings.gradle .
+
+RUN chmod +x gradlew
+
+RUN ./gradlew build -x test --parallel --continue || true
+
+COPY src src
+
+RUN ./gradlew clean build -x test --stacktrace --info
+
+FROM public.ecr.aws/docker/library/openjdk:17-jdk-slim
+
+WORKDIR /app
+
+COPY --from=builder /home/gradle/app/build/libs/*.jar app.jar
+
+EXPOSE 8100
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 연관된 이슈
resolve #14 

## 작업 내용
TmbmBackend Application 을 Dockerize하여 플랫폼에 종속되지 않고 Application이 구동될 수 있도록 Dockerfile을 작성합니다. 

- AWS ECR public ecr repository 를 내에서 공유된 경량화된 이미지인 gradle:7.4.2-jdk17과 openjdk:17-jdk-slim 이미지를 사용합니다.
- gradle 빌드 이미지를 최적화 합니다.
-  필요에 따라 build 파일에 실행 권한을 부여하고, 캐시를 사용하여 빌드 타임을 최적화 하였습니다.